### PR TITLE
+added trigger: distinguish comments as mod comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Next, each community has a list of triggers. Each trigger has a `triggerType` th
 
 When a trigger is triggered, its `actions` will get executed from top to bottom. Currently these actions are available:
 
-- `postComment`: Creates a comment to the matching post/comment. The content of the comment will be the `message`. With `"modComment": true` the comment gets automatically marked as a mod comment.
-- `remove`: Removes or restores the post/comment. (`"value": True` means remove, `"value": False means restore, `"reason"` contains the reason that is given in the modlog)
-- `lock`: (Posts only) Locks or unlocks the post. (`"value": True` means lock, `"value": False` means unlock)
+- `postComment`: Creates a comment to the matching post/comment. The content of the comment will be the `message`. With `"distinguish": true` the comment gets automatically marked as a mod comment.
+- `remove`: Removes or restores the post/comment. (`"value": true` means remove, `"value": false means restore, `"reason"` contains the reason that is given in the modlog)
+- `lock`: (Posts only) Locks or unlocks the post. (`"value": true` means lock, `"value": false` means unlock)
 - `report`: Reports a post or a comment to the moderators. `reason` contains the reason for the report.
 
 The fields `content` and `reason` can use Python's string formatting to inject values from the affected posts/comments.

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ Next, each community has a list of triggers. Each trigger has a `triggerType` th
 
 When a trigger is triggered, its `actions` will get executed from top to bottom. Currently these actions are available:
 
-- `postComment`: Creates a comment to the matching post/comment. The content of the comment will be the `message`.
+- `postComment`: Creates a comment to the matching post/comment. The content of the comment will be the `message`. With `"modComment": true` the comment gets automatically marked as a mod comment.
 - `remove`: Removes or restores the post/comment. (`"value": True` means remove, `"value": False means restore, `"reason"` contains the reason that is given in the modlog)
 - `lock`: (Posts only) Locks or unlocks the post. (`"value": True` means lock, `"value": False` means unlock)
+- `report`: Reports a post or a comment to the moderators. `reason` contains the reason for the report.
 
 The fields `content` and `reason` can use Python's string formatting to inject values from the affected posts/comments.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pythorhead==0.15.2
+pythorhead==0.15.4
 timeout-decorator==0.5.0

--- a/squareModBot.py
+++ b/squareModBot.py
@@ -135,7 +135,7 @@ def executePostActions(trigger, actionSubjectList):
 				print(f"-> Creating comment: {content}")
 				newComment = lemmy.comment.create(post_id = postId, content = content)
 				
-				if action["modComment"] == True:
+				if action["distinguish"] == True:
 					print(f"-> Distinguishing (Mark as Modcomment) comment: {content}")
 					lemmy.comment.distinguish(newComment["comment_view"]["comment"]["id"], True)
 
@@ -169,7 +169,7 @@ def executeCommentActions(trigger, actionSubjectList):
 				print(f"-> Creating comment: {content}")
 				newComment = lemmy.comment.create(post_id = subject["targetComment"]["post"]["id"], parent_id = commentId, content = content)
 
-				if action["modComment"] == True:
+				if action["distinguish"] == True:
 					print(f"-> Distinguishing (Mark as Modcomment) comment: {content}")
 					lemmy.comment.distinguish(newComment["comment_view"]["comment"]["id"], True)
 

--- a/squareModBot.py
+++ b/squareModBot.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF8 -*-
 
 from time import time, sleep
-from pythorhead import Lemmy
+from pythorhead import Lemmy, requestor
 from pythorhead.types.sort import SortType
 from pythorhead.types.listing import ListingType
 import re
@@ -162,7 +162,15 @@ def executeCommentActions(trigger, actionSubjectList):
 			if action["type"] == "postComment":
 				content = templateString(action["content"], {"targetComment": subject["targetComment"]})
 				print(f"-> Creating comment: {content}")
-				lemmy.comment.create(post_id = subject["targetComment"]["post"]["id"], parent_id = commentId, content = content)
+				newComment = lemmy.comment.create(post_id = subject["targetComment"]["post"]["id"], parent_id = commentId, content = content)
+
+
+				if action["modComment"] == True:
+					#Apperently pythorhead doesn't correctly implement the way to distinguish a comment
+					#so we have to do it this way, for now.
+					print(f"-> Distinguishing (Mark as Modcomment) comment: {content}")
+					lemmy.comment._requestor.api(requestor.Request.POST, "/comment/distinguish", json={"comment_id" : newComment["comment_view"]["comment"]["id"], "distinguished" : True })
+
 			elif action["type"] == "remove":
 				reason = templateString(action["reason"], {"targetComment": subject["targetComment"]})
 				print(f"-> Removing comment {commentId} with the following reason: {reason}")


### PR DESCRIPTION
Added a new trigger to distinguish a comment as a mod comment when posted by the bot.
The trigger is a boolean called "modComment".

Since the api call to edit doesn't work in pythorhead the HTTP api gets called directly using the requestor api.